### PR TITLE
Fix: Font fallback minor fix

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ export default {
       },
       fontFamily: {
         montserrat: ['Montserrat', 'sans-serif'],
-        fraunces: ['Fraunces', 'sans-serif'],
+        fraunces: ['Fraunces', 'serif'],
       },
       colors: {
         customYellow: '#FFC02C',


### PR DESCRIPTION
This is a minor follow-up fix to ensure the correct font fallback. Previously the Fraunces fallback was set to sans-serif, but it should be serif.